### PR TITLE
Reparent bullets

### DIFF
--- a/src/gun/bullet.gd
+++ b/src/gun/bullet.gd
@@ -1,6 +1,7 @@
 extends Area2D
 
 export(int, 0, 12000) var speed := 1
+export(int) var multiplier := 1
 var direction = Vector2.ZERO
 
 

--- a/src/player/player.gd
+++ b/src/player/player.gd
@@ -1,6 +1,7 @@
 extends KinematicBody2D
 
 export(int, 0, 12000) var speed := 1
+export(int) var multiplier := 1
 
 
 func _ready():
@@ -23,7 +24,7 @@ func _physics_process(delta):
 	direction = direction.clamped(1.0)
 
 	# warning-ignore:return_value_discarded
-	move_and_slide(direction * speed * delta, Vector2.ZERO)
+	move_and_slide(direction * speed * multiplier * delta, Vector2.ZERO)
 
 
 func _on_timeout():

--- a/src/player/player.gd
+++ b/src/player/player.gd
@@ -29,5 +29,7 @@ func _physics_process(delta):
 
 func _on_timeout():
 	var spawned_bullet = $Bullet.create_instance()
+	remove_child(spawned_bullet)
+	get_parent().add_child(spawned_bullet)
 	spawned_bullet.global_position = self.global_position
 	spawned_bullet.direction = get_local_mouse_position()


### PR DESCRIPTION
- The current behaviour makes the bullets follow the player movements. This re-parents the bullets to the player's parent node after spawning.
- Adds `multiplier` to take scaling into account.